### PR TITLE
Update upstream actions' versions

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -34,7 +34,7 @@ runs:
   using: 'composite'
   steps:
     - name: 'Checkout repository'
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         persist-credentials: ${{ inputs.persist-credentials }}
         fetch-depth: ${{ inputs.fetch-depth }}
@@ -46,7 +46,7 @@ runs:
         repo-token: ${{ inputs.repo-token }}
 
     - name: 'Setup dependencies and cache'
-      uses: wyvox/action-setup-pnpm@v2
+      uses: wyvox/action-setup-pnpm@v3
       with: 
         node-version: ${{ inputs.node-version }}
         pnpm-version: ${{ inputs.pnpm-version }}


### PR DESCRIPTION
actions/checkout: https://github.com/actions/checkout/releases/tag/v4.0.0
(nothing major here, only the default node has changed)

action-setup-pnpm: https://github.com/wyvox/action-setup-pnpm/releases/tag/v3.0.0
(nothing major here, dropped unsupported option, unused by wyvox/action)