### PR TITLE
Update GitHub Action dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
           - 16
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - uses: ./
         with:
           node-version: ${{ matrix.node }}

--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -15,7 +15,7 @@ jobs:
     name: Check licenses
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
       - name: Install dependencies
         uses: ./
       - name: Install licensed tool

--- a/.github/workflows/sync-release.yml
+++ b/.github/workflows/sync-release.yml
@@ -22,6 +22,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Update the ${{ env.TAG_NAME }} tag
-        uses: actions/publish-action@v0.2.2
+        uses: actions/publish-action@v0.4.0
         with:
           source-tag: ${{ env.TAG_NAME }}

--- a/action.yml
+++ b/action.yml
@@ -44,7 +44,7 @@ runs:
   using: 'composite'
   steps:
     - name: 'Checkout repository'
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         persist-credentials: ${{ inputs.persist-credentials }}
         fetch-depth: ${{ inputs.fetch-depth }}
@@ -52,7 +52,7 @@ runs:
 
     - name: 'Setup local TurboRepo server'
       if: ${{ inputs.repo-token }}
-      uses: felixmosh/turborepo-gh-artifacts@v3
+      uses: felixmosh/turborepo-gh-artifacts@v4
       with:
         repo-token: ${{ inputs.repo-token }}
 


### PR DESCRIPTION
## Summary

- Update `actions/checkout` from v3/v4 to v6 across `action.yml`, `ci.yml`, and `license.yml`
- Update `felixmosh/turborepo-gh-artifacts` from v3 to v4 in `action.yml`
- Update `actions/publish-action` from v0.2.2 to v0.4.0 in `sync-release.yml`

## Test plan

- [ ] Verify CI workflow runs successfully with `actions/checkout@v6`
- [ ] Verify turborepo artifact caching works with `felixmosh/turborepo-gh-artifacts@v4`
- [ ] Verify release sync workflow with `actions/publish-action@v0.4.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)